### PR TITLE
fixed python matmul bug

### DIFF
--- a/rigid_transform_3D.py
+++ b/rigid_transform_3D.py
@@ -33,7 +33,7 @@ def rigid_transform_3D(A, B):
     Am = A - tile(centroid_A, (1, num_cols))
     Bm = B - tile(centroid_B, (1, num_cols))
 
-    H = Am * transpose(Bm)
+    H = matmul(Am, transpose(Bm))
 
     # sanity check
     #if linalg.matrix_rank(H) < 3:


### PR DESCRIPTION
In the python file, the matrix multiplication operation seems to be wrong,
Am * transpose(Bm) --> will do an elementwise multiplication
We should use np.matmul for matrix multiplication.